### PR TITLE
Add optional configuration for Apache virtualhost aliases

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 # zabbix role specific
 
 zabbix_url: zabbix.example.com
+zabbix_url_aliases: []
 zabbix_version: 2.4
 zabbix_timezone: Europe/Amsterdam
 zabbix_repo: True

--- a/templates/apache_vhost.conf.j2
+++ b/templates/apache_vhost.conf.j2
@@ -1,5 +1,8 @@
 <VirtualHost *:80>
   ServerName {{ zabbix_url }}
+  {% for alias in zabbix_url_aliases %}
+  ServerAlias {{ alias }}
+  {% endfor %}
 
   ## Vhost docroot
   DocumentRoot "/usr/share/zabbix"


### PR DESCRIPTION
Add optional configuration for Apache virtualhost aliases

Default is an empty list, can be extended wit a list of aliases.