### PR TITLE
Fix missed required space

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -26,7 +26,7 @@
   when: zabbix_database_sqlload
 
 - name: "MySQL | Importing images file"
-  shell: "cd {{ datafiles_path }} && mysql -h '{{ server_dbhost }}' -u '{{ server_dbuser }} '-p'{{ server_dbpassword }}' -D '{{ server_dbname }}' < images.sql && touch /etc/zabbix/images.done"
+  shell: "cd {{ datafiles_path }} && mysql -h '{{ server_dbhost }}' -u '{{ server_dbuser }}' -p'{{ server_dbpassword }}' -D '{{ server_dbname }}' < images.sql && touch /etc/zabbix/images.done"
   args:
     creates: /etc/zabbix/images.done
   when: zabbix_database_sqlload


### PR DESCRIPTION
in Importing images file task there's missing space with leads to
```
stderr: ERROR 1044 (42000): Access denied for user ''@'localhost' to database 'zabbix'
```