### PR TITLE
Force apt cache update after installing Zabbix's gpg key

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -34,7 +34,6 @@
   apt: pkg=zabbix-server-{{ database_type }}
        state=present
        update_cache=yes
-       cache_valid_time=3600
 
 - name: "Debian | Install php5-{{ database_type }}"
   apt: pkg=php5-{{ database_type }}


### PR DESCRIPTION
While I was testing zabbix-server role I encounter the following
problem:
```
...
WARNING: The following packages cannot be authenticated!
zabbix-server-mysql

msg: '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"   install 'zabbix-server-mysql'' failed: E: There are problems and -y was used without --force-yes

FATAL: all hosts have already failed -- aborting
```
This happens only when I call zabbix-server role quickly after other
role that updates apt cache.
I trace the problem to Debian.yml file "Installing zabbix-server-mysql"
task @ line 33.
According to apt module documentation [1] setting update_cashe to yes
should force cache update, but the next statment cache_valid_time=3600
will skip the update if the apt-cache has been ran in the last hour. But
if the cache is not updated after adding Zabbix's gpg key apt has no way
to vefify the integraty of the .deb file.

In order to force an cache update after adding Zabbix's key the statment
cache_valid_time=3600 has been removed.

Posible improvment would be to force apt cache update only if previus
task (adding the gpg key) have made real configuration change.

[1] http://docs.ansible.com/apt_module.html