### PR TITLE
fix #2: server_dbhost allows for remote database but role does not fully support setting up on remote db

### DIFF
--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -6,6 +6,7 @@
                  state=present
   sudo: yes
   sudo_user: postgres
+  delegate_to: "{{server_dbhost}}"
   when: zabbix_database_creation
   tags:
     - zabbix-server
@@ -19,6 +20,7 @@
                    state=present
   sudo: yes
   sudo_user: postgres
+  delegate_to: "{{server_dbhost}}"
   when: zabbix_database_creation
   tags:
     - zabbix-server

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -1,12 +1,16 @@
 ---
 # task file for postgresql
 
+- name: set the correct delegated_dbhost (to support postgres db deployment on a remote dbhost)
+  set_fact:
+    delegated_dbhost: "{{server_dbhost if (server_dbhost != 'localhost') else inventory_hostname}}"
+
 - name: "PostgreSQL | Create database"
   postgresql_db: name={{ server_dbname }}
                  state=present
   sudo: yes
   sudo_user: postgres
-  delegate_to: "{{server_dbhost}}"
+  delegate_to: "{{delegated_dbhost}}"
   when: zabbix_database_creation
   tags:
     - zabbix-server
@@ -20,7 +24,7 @@
                    state=present
   sudo: yes
   sudo_user: postgres
-  delegate_to: "{{server_dbhost}}"
+  delegate_to: "{{delegated_dbhost}}"
   when: zabbix_database_creation
   tags:
     - zabbix-server


### PR DESCRIPTION
delegate_to to the rescue !
I'm not sure if I missed anything, but the fix worked in our case, with postgres on a different host.

Update: @dj-wasabi I fixed my initial PR. Should be good to merge now! 