### PR TITLE
Add SELinux specifics

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -90,3 +90,6 @@ server_tlskeyfile:
 server_startescalators: 1
 server_vmwareperffrequency: 60
 server_vmwaretimeout: 10
+
+# SELinux specific 
+selinux_allow_zabbix_can_network: False

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -112,3 +112,32 @@
   when: database_type == 'pgsql'
   tags:
     - zabbix-server
+
+- name: "RedHat | Install related SELinux package"
+  yum: name={{ item }}
+       state=present
+  with_items:
+    - libsemanage-python
+  when: zabbix_web or selinux_allow_zabbix_can_network
+  tags:
+    - zabbix-server
+
+- name: "RedHat | Enable httpd_can_connect_zabbix SELinux boolean"
+  seboolean: name={{ item }} 
+             state=yes 
+             persistent=yes
+  with_items:
+    - httpd_can_connect_zabbix
+  when: zabbix_web
+  tags:
+    - zabbix-server 
+
+- name: "RedHat | Enable zabbix_can_network SELinux boolean"
+  seboolean: name={{ item }} 
+             state=yes 
+             persistent=yes
+  with_items:
+    - zabbix_can_network
+  when: selinux_allow_zabbix_can_network
+  tags:
+    - zabbix-server


### PR DESCRIPTION
If SELinux is running in an Enforce mode on a OSes like RHEL, the Zabbix
Web interface via 'httpd' will not be able to connect to the Zabbix server
after the deployment, as this is disallowed by the SELinux policy by
default. To control it, we can use Ansible's 'seboolean' feature from
the systems modules, and set 'httpd_can_connect_zabbix' to True.

Also, we should be able to set 'zabbix_can_network' sebool value to True
during deployment, to allow Zabbix server to connect to any TCP port, as
some specific Infras environments might require it. However, keep the
'zabbix_can_network' as disabled by default.
Note, that 'selinux_allow_zabbix_can_network' control variable should be
stored in defaults/main.yml, as SELinux can be deployed on any
Linux distro, these Debian based too, but as we see now, only on RHEL
based its installed by default.