### PR TITLE
fix early failures when running the zabbix-server playbook in check-mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,16 +5,23 @@
   set_fact:
       zabbix_short_version: "{{ zabbix_version | regex_replace('\\.', '') }}"
   tags:
-    - zabbix-server
+    - always
 
 - name: "Get Apache version"
   action: shell apachectl -v | grep 'version' | awk -F '/' '{ print $2 }'| awk '{ print $1 }' | cut -c 1-3
   changed_when: apachectl_version.rc == 7
   register: apachectl_version
+  always_run: yes
+  tags:
+    - zabbix-server
+    - apache
 
 - name: "Set correct apache_version"
   set_fact:
     apache_version: "{{ apachectl_version.stdout }}"
+  tags:
+    - zabbix-server
+    - apache
 
 - name: "Install the correct repository"
   include: "RedHat.yml"


### PR DESCRIPTION
After the changes in this PR,  running in `--check` mode should not fail anymore at following tasks (fixes done for Debian/Ubuntu):

```
TASK [../../../ansible-zabbix-server : Set correct apache_version] *************
fatal: [hw07]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'dict object' has no attribute 'stdout'\n\nThe error appears to have been in '/Users/lhoss/IdeaProjects/ansible-zabbix-server/tasks/main.yml': line 17, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Set correct apache_version\"\n  ^ here\n"}

...

TASK [../../../ansible-zabbix-server : Debian | Set some facts] ****************
fatal: [hw07]: FAILED! => {"failed": true, "msg": "The conditional check 'zabbix_short_version < 30' failed. The error was: error while evaluating conditional (zabbix_short_version < 30): 'zabbix_short_version' is undefined\n\nThe error appears to have been in '/Users/lhoss/IdeaProjects/ansible-zabbix-server/tasks/Debian.yml': line 3, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: \"Debian | Set some facts\"\n  ^ here\n"}
```
