### PR TITLE
debian/ubuntu: install postgresql-client pkg (instead of postgresql which contains the postgres server)

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -117,7 +117,7 @@
     - database
 
 - name: "Debian | Install PostgreSQL Client package"
-  apt: name=postgresql
+  apt: name=postgresql-client
        state=present
   when: database_type == 'pgsql'
   tags:


### PR DESCRIPTION
Additional note:
I found a slight inconsistency only for the case: "zabbix-server and (postgres)DB installed on different hosts" (which I contributed a patch for  some time ago)
The role does not ensure that the `server_dbhost` (host running postgres-server) has the postgres-client installed.
IMO a more proper (re)implementation of that use-case, would be to use the postgres-client installed on the zabbix-host (and `postgresql_db` attribute `login_host` )
instead of the current:
```
  delegate_to: "{{ delegated_dbhost }}"
```
( Additional advantage, this would also work with a postgres-server serviced by a docker container ! )
Of course one had to ensure the postgres-server is allowed access from the (then remote) zabbix host (which is required anyway to run zabbix later!)

I could do a sep. PR for this  (but without touching the mysql case)