### PR TITLE
Changed the dependency-definition to get rid of a deprecation warning

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,4 +22,4 @@ galaxy_info:
   categories:
   - monitoring
 dependencies:
-- { src: geerlingguy.apache, tags: apache }
+- { name: geerlingguy.apache, src: geerlingguy.apache, tags: apache }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -22,4 +22,4 @@ galaxy_info:
   categories:
   - monitoring
 dependencies:
-- { role: geerlingguy.apache, tags: apache }
+- { src: geerlingguy.apache, tags: apache }


### PR DESCRIPTION
Version: Ansible 2.2.0.0
Warning displayed: 
```
[DEPRECATION WARNING]: The comma separated role spec format, use the yaml/explicit format instead..
 This feature will be removed in a future release. Deprecation warnings can be disabled by setting
 deprecation_warnings=False in ansible.cfg.
```