### PR TITLE
Fix permissions on Zabbix includedir

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,7 +52,7 @@
     owner: zabbix
     group: zabbix
     state: directory
-    mode: 0644
+    mode: 0755
   tags:
     - zabbix-server
     - init


### PR DESCRIPTION
Permissions are currently set to 0644.
This can't work as this is a directory and it'll contain files.
Files should be set to 0644 but directories set to 0755 as it needs
execution rights to go through.