### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,11 @@ There are some zabbix-server specific variables which will be used for the zabbi
 
 There are 2 database_types which will be supported: mysql and postgresql. You'll need to comment or uncomment the database you would like to use and adjust the port number (`server_dbport`) accordingly (`5432` is the default postgresql port). In example from above, the postgresql database is used. If you want to use mysql, uncomment the 2 lines from mysql and comment the 2 lines for postgresql and change the database port to the mysql one (default mysql port is `3306`).
 
+If you use mysql, then you should define mysql username, password and host to prepare zabbix database, otherwise they will be considered as their default value (and therefor, connecting to database will be considered as connecting to localhost with no password). the keys are belows:
+   zabbix_server_mysql_login_host
+   zabbix_server_mysql_login_user
+   zabbix_server_mysql_login_password
+
 # Dependencies
 
 This role has 1 "hardcoded" dependency: geerlingguy.apache. This is an role which support the 3 main operating systems (Red Hat/Debian/Ubuntu). I can't find an mysql or postgresql role which also supports these 3 operating systems.


### PR DESCRIPTION
I saw that although I defined user and password for zabbix_server_mysql_(user/pass) but ansible tries to connect to mysql with 'no password'.