### PR TITLE
Supporting oses

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ See the following list of supported Operating systems with the Zabbix releases.
   * OracleLinux 7.x
   * Scientific Linux 7.x
   * Ubuntu 14.04, 16.04
-  * Debian 7, 8
+  * Debian 7, 8, 9
 
 
 ### Zabbix 3.2

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Installing and maintaining zabbix-server for RedHat/Debian/Ubuntu.
   company: myCompany.Dotcom
   license: license (GPLv3)
-  min_ansible_version: 1.9
+  min_ansible_version: 2.4
   platforms:
     - name: EL
       versions:

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: False
-  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+#  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -3,7 +3,7 @@
   hosts: localhost
   connection: local
   gather_facts: False
-#  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
+  no_log: "{{ not lookup('env', 'MOLECULE_DEBUG') | bool }}"
   vars:
     molecule_file: "{{ lookup('env', 'MOLECULE_FILE') }}"
     molecule_ephemeral_directory: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,38 +13,40 @@ lint:
   options:
     config-file: molecule/default/yaml-lint.yml
 platforms:
-  - name: zabbix-server-mysql-centos
-    image: milcom/centos7-systemd
-    privileged: True
-    groups:
-      - mysql
-  - name: zabbix-server-pgsql-centos
-    image: milcom/centos7-systemd
-    privileged: True
-    groups:
-      - postgresql
+#  - name: zabbix-server-mysql-centos
+#    image: milcom/centos7-systemd
+#    privileged: True
+#    groups:
+#      - mysql
+#  - name: zabbix-server-pgsql-centos
+#    image: milcom/centos7-systemd
+#    privileged: True
+#    groups:
+#      - postgresql
   - name: zabbix-server-mysql-debian
-    image: maint/debian-systemd
+    image: minimum2scp/systemd-stretch
     privileged: True
+    command: /sbin/init
     groups:
       - mysql
   - name: zabbix-server-pgsql-debian
-    image: maint/debian-systemd
-    privileged: True
-    groups:
-      - postgresql
-  - name: zabbix-server-mysql-ubuntu
-    image: solita/ubuntu-systemd:latest
-    privileged: True
-    command: /sbin/init
-    groups:
-      - mysql
-  - name: zabbix-server-pgsql-ubuntu
-    image: solita/ubuntu-systemd:latest
+    image: minimum2scp/systemd-stretch
     privileged: True
     command: /sbin/init
     groups:
       - postgresql
+#  - name: zabbix-server-mysql-ubuntu
+#    image: solita/ubuntu-systemd:xenial
+#    privileged: True
+#    command: /sbin/init
+#    groups:
+#      - mysql
+#  - name: zabbix-server-pgsql-ubuntu
+#    image: solita/ubuntu-systemd:xenial
+#    privileged: True
+#    command: /sbin/init
+#    groups:
+#      - postgresql
 
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,16 +13,16 @@ lint:
   options:
     config-file: molecule/default/yaml-lint.yml
 platforms:
-#  - name: zabbix-server-mysql-centos
-#    image: milcom/centos7-systemd
-#    privileged: True
-#    groups:
-#      - mysql
-#  - name: zabbix-server-pgsql-centos
-#    image: milcom/centos7-systemd
-#    privileged: True
-#    groups:
-#      - postgresql
+  - name: zabbix-server-mysql-centos
+    image: milcom/centos7-systemd
+    privileged: True
+    groups:
+      - mysql
+  - name: zabbix-server-pgsql-centos
+    image: milcom/centos7-systemd
+    privileged: True
+    groups:
+      - postgresql
   - name: zabbix-server-mysql-debian
     image: minimum2scp/systemd-stretch
     privileged: True
@@ -35,18 +35,18 @@ platforms:
     command: /sbin/init
     groups:
       - postgresql
-#  - name: zabbix-server-mysql-ubuntu
-#    image: solita/ubuntu-systemd:xenial
-#    privileged: True
-#    command: /sbin/init
-#    groups:
-#      - mysql
-#  - name: zabbix-server-pgsql-ubuntu
-#    image: solita/ubuntu-systemd:xenial
-#    privileged: True
-#    command: /sbin/init
-#    groups:
-#      - postgresql
+  - name: zabbix-server-mysql-ubuntu
+    image: solita/ubuntu-systemd:xenial
+    privileged: True
+    command: /sbin/init
+    groups:
+      - mysql
+  - name: zabbix-server-pgsql-ubuntu
+    image: solita/ubuntu-systemd:xenial
+    privileged: True
+    command: /sbin/init
+    groups:
+      - postgresql
 
 provisioner:
   name: ansible

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,7 +5,7 @@
     - name: "Installing packages"
       yum:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - net-tools
         - which
@@ -16,9 +16,10 @@
     - name: "Installing which on NON-CentOS"
       apt:
         name: "{{ item }}"
-        state: installed
+        state: present
       with_items:
         - net-tools
+        - apt-utils
       when: ansible_os_family != 'RedHat'
 
     - name: "Configure SUDO."

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,10 +1,17 @@
 ---
 
+- name: "Include Zabbix gpg ids"
+  include_vars: zabbix.yml
+
+- name: "Set short version name"
+  set_fact:
+    zabbix_short_version: "{{ zabbix_version | regex_replace('\\.', '') }}"
+
 - name: "Debian | Set some facts"
   set_fact:
     datafiles_path: /usr/share/zabbix-server-{{ database_type }}
   when:
-    - zabbix_version | version_compare('3.0', '<')
+    - zabbix_version is version_compare('3.0', '<')
   tags:
     - zabbix-server
     - init
@@ -14,21 +21,7 @@
   set_fact:
     datafiles_path: /usr/share/doc/zabbix-server-{{ database_type }}
   when:
-    - zabbix_version | version_compare('3.0', '>=')
-  tags:
-    - zabbix-server
-    - init
-    - config
-
-- name: "Debian | Installing repository {{ ansible_distribution }}"
-  apt_repository:
-    repo: "{{ item }} http://repo.zabbix.com/zabbix/{{ zabbix_version }}/{{ ansible_distribution.lower() }}/ {{ ansible_distribution_release }} main"
-    state: present
-  when:
-    - zabbix_repo == "zabbix"
-  with_items:
-    - deb-src
-    - deb
+    - zabbix_version is version_compare('3.0', '>=')
   tags:
     - zabbix-server
     - init
@@ -36,17 +29,67 @@
 
 - name: "Debian | Install gpg key"
   apt_key:
+    id: "{{ sign_keys[zabbix_short_version][ansible_distribution_release]['sign_key'] }}"
     url: http://repo.zabbix.com/zabbix-official-repo.key
-    state: present
   when:
     - zabbix_repo == "zabbix"
+  become: yes
   tags:
     - zabbix-server
     - init
-    - config
+
+- name: "Debian | Installing deb-src repository Ubuntu"
+  apt_repository:
+    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_distribution_release }} main"
+    state: present
+  when:
+    - ansible_distribution == "Ubuntu"
+    - zabbix_repo == "zabbix"
+  become: yes
+  tags:
+    - zabbix-server
+    - init
+
+- name: "Debian | Installing deb repository Debian"
+  apt_repository:
+    repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_distribution_release }} main"
+    state: present
+  when:
+    - ansible_distribution == "Debian"
+    - zabbix_repo == "zabbix"
+  become: yes
+  tags:
+    - zabbix-server
+    - init
+
+- name: "Debian | Installing deb-src repository Debian"
+  apt_repository:
+    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_distribution_release }} main"
+    state: present
+  when:
+    - ansible_distribution == "Debian"
+    - zabbix_repo == "zabbix"
+  become: yes
+  tags:
+    - zabbix-server
+    - init
+
+- name: "Debian | Installing deb repository Ubuntu"
+  apt_repository:
+    repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_distribution_release }} main"
+    state: present
+  when:
+    - ansible_distribution == "Ubuntu"
+    - zabbix_repo == "zabbix"
+  become: yes
+  tags:
+    - zabbix-server
+    - init
 
 - name: apt-get clean
   shell: apt-get clean; rm -rf /tmp/*; apt-get update
+  args:
+    warn: False
   changed_when: False
   tags:
     - skip_ansible_lint

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -38,50 +38,14 @@
     - zabbix-server
     - init
 
-- name: "Debian | Installing deb-src repository Ubuntu"
+- name: "Debian | Installing repository {{ ansible_distribution }}"
   apt_repository:
-    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_distribution_release }} main"
+    repo: "{{ item }} http://repo.zabbix.com/zabbix/{{ zabbix_version }}/{{ ansible_distribution.lower() }}/ {{ ansible_distribution_release }} main"
     state: present
-  when:
-    - ansible_distribution == "Ubuntu"
-    - zabbix_repo == "zabbix"
-  become: yes
-  tags:
-    - zabbix-server
-    - init
-
-- name: "Debian | Installing deb repository Debian"
-  apt_repository:
-    repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_distribution_release }} main"
-    state: present
-  when:
-    - ansible_distribution == "Debian"
-    - zabbix_repo == "zabbix"
-  become: yes
-  tags:
-    - zabbix-server
-    - init
-
-- name: "Debian | Installing deb-src repository Debian"
-  apt_repository:
-    repo: "deb-src http://repo.zabbix.com/zabbix/{{ zabbix_version }}/debian/ {{ ansible_distribution_release }} main"
-    state: present
-  when:
-    - ansible_distribution == "Debian"
-    - zabbix_repo == "zabbix"
-  become: yes
-  tags:
-    - zabbix-server
-    - init
-
-- name: "Debian | Installing deb repository Ubuntu"
-  apt_repository:
-    repo: "deb http://repo.zabbix.com/zabbix/{{ zabbix_version }}/ubuntu/ {{ ansible_distribution_release }} main"
-    state: present
-  when:
-    - ansible_distribution == "Ubuntu"
-    - zabbix_repo == "zabbix"
-  become: yes
+  when: zabbix_repo == "zabbix"
+  with_items:
+    - deb-src
+    - deb
   tags:
     - zabbix-server
     - init

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -29,7 +29,7 @@
   set_fact:
     datafiles_path: "/usr/share/doc/zabbix-server-{{ database_type }}-{{ zabbix_version }}*/create"
   when:
-    - zabbix_version | version_compare('3.0', '<')
+    - zabbix_version is version_compare('3.0', '<')
   tags:
     - zabbix-server
 
@@ -37,7 +37,7 @@
   set_fact:
     datafiles_path: "/usr/share/doc/zabbix-server-{{ database_type }}-{{ zabbix_version }}*"
   when:
-    - zabbix_version | version_compare('3.0', '>=')
+    - zabbix_version is version_compare('3.0', '>=')
   tags:
     - zabbix-server
 

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -37,7 +37,7 @@
   shell: ls -1 {{ datafiles_path }}/create.sq*
   changed_when: False
   when:
-    - zabbix_version | version_compare('3.0', '>=')
+    - zabbix_version is version_compare('3.0', '>=')
     - zabbix_database_sqlload
   register: ls_output_create
   tags:
@@ -49,7 +49,7 @@
     path: /etc/zabbix/create.done
   register: done_file
   when:
-    - zabbix_version | version_compare('3.0', '>=')
+    - zabbix_version is version_compare('3.0', '>=')
     - zabbix_database_sqlload
 
 - name: "MySQL | Create database and import file >= 3.0"
@@ -60,7 +60,7 @@
     state: import
     target: "{{ ls_output_create.stdout }}"
   when:
-    - zabbix_version | version_compare('3.0', '>=')
+    - zabbix_version is version_compare('3.0', '>=')
     - zabbix_database_sqlload
     - not done_file.stat.exists
   delegate_to: "{{ delegated_dbhost }}"
@@ -73,7 +73,7 @@
     path: /etc/zabbix/create.done
     state: touch
   when:
-    - zabbix_version | version_compare('3.0', '>=')
+    - zabbix_version is version_compare('3.0', '>=')
     - zabbix_database_sqlload
     - not done_file.stat.exists
 
@@ -86,7 +86,7 @@
     - images
     - data
   when:
-    - zabbix_version | version_compare('3.0', '<')
+    - zabbix_version is version_compare('3.0', '<')
     - zabbix_database_sqlload
   tags:
     - zabbix-server
@@ -101,7 +101,7 @@
     - images
     - data
   when:
-    - zabbix_version | version_compare('3.0', '<')
+    - zabbix_version is version_compare('3.0', '<')
     - zabbix_database_sqlload
   tags:
     - zabbix-server
@@ -112,7 +112,7 @@
     sql_files_executed: "{{ sql_files_executed | default({}) | combine({item.item: item.stat}) }}"
   with_items: "{{ done_files.results }}"
   when:
-    - zabbix_version | version_compare('3.0', '<')
+    - zabbix_version is version_compare('3.0', '<')
     - zabbix_database_sqlload
   tags:
     - zabbix-server
@@ -127,7 +127,7 @@
     target: "{{ item.stdout }}"
   with_items: "{{ ls_output_schema.results }}"
   when:
-    - zabbix_version | version_compare('3.0', '<')
+    - zabbix_version is version_compare('3.0', '<')
     - zabbix_database_sqlload
     - not sql_files_executed[item.item].exists
   delegate_to: "{{ delegated_dbhost }}"
@@ -144,7 +144,7 @@
     - images
     - data
   when:
-    - zabbix_version | version_compare('3.0', '<')
+    - zabbix_version is version_compare('3.0', '<')
     - zabbix_database_sqlload
     - not sql_files_executed[item].exists
   tags:

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -44,7 +44,7 @@
   environment:
     PGPASSWORD: '{{ zabbix_server_dbpassword }}'
   when:
-    - zabbix_version | version_compare('3.0', '>=')
+    - zabbix_version is version_compare('3.0', '>=')
     - zabbix_database_sqlload
   tags:
     - zabbix-server
@@ -57,7 +57,7 @@
   environment:
     PGPASSWORD: '{{ zabbix_server_dbpassword }}'
   when:
-    - (zabbix_version | version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
+    - (zabbix_version is version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server
     - database
@@ -68,7 +68,7 @@
     creates: /etc/zabbix/images.done
   environment:
     PGPASSWORD: '{{ zabbix_server_dbpassword }}'
-  when: (zabbix_version | version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
+  when: (zabbix_version is version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server
     - database
@@ -79,7 +79,7 @@
     creates: /etc/zabbix/data.done
   environment:
     PGPASSWORD: '{{ zabbix_server_dbpassword }}'
-  when: (zabbix_version | version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
+  when: (zabbix_version is version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server
     - database

--- a/templates/zabbix_server.conf.j2
+++ b/templates/zabbix_server.conf.j2
@@ -126,8 +126,7 @@ StartDiscoverers={{ zabbix_server_startdiscoverers }}
 #
 StartHTTPPollers={{ zabbix_server_starthttppollers }}
 
-{#{% if zabbix_short_version >= '20' %}#}
-{% if zabbix_version | version_compare('2.0', '>=') %}
+{% if zabbix_version is version_compare('2.0', '>=') %}
 ### option: starttimers
 #	number of pre-forked instances of timers.
 #	timers process time-based trigger functions and maintenance periods.
@@ -136,8 +135,7 @@ StartHTTPPollers={{ zabbix_server_starthttppollers }}
 StartTimers={{ zabbix_server_starttimers }}
 {% endif %}
 
-{#{% if zabbix_short_version >= '30' %}#}
-{% if zabbix_version | version_compare('3.0', '>=') %}
+{% if zabbix_version is version_compare('3.0', '>=') %}
 ### Option: StartEscalators
 #   Number of pre-forked instances of escalators.
 #
@@ -162,8 +160,7 @@ JavaGatewayPort={{ zabbix_server_javagatewayport }}
 StartJavaPollers={{ zabbix_server_startjavapollers }}
 {% endif  %}
 
-{#{% if zabbix_short_version >= '2.2' %}#}
-{% if zabbix_version | version_compare('2.2', '>=') %}
+{% if zabbix_version is version_compare('2.2', '>=') %}
     ### option: startvmwarecollectors
 #	number of pre-forked vmware collector instances.
 #
@@ -174,8 +171,7 @@ StartVMwareCollectors={{ zabbix_server_startvmwarecollectors }}
 #
 VMwareFrequency={{ zabbix_server_vmwarefrequency }}
 
-{#{% if zabbix_short_version >= '30' %}#}
-{% if zabbix_version | version_compare('3.0', '>=') %}
+{% if zabbix_version is version_compare('3.0', '>=') %}
 ### Option: VMwarePerfFrequency
 #       How often Zabbix will connect to VMware service to obtain performance data.
 #
@@ -191,8 +187,7 @@ VMwarePerfFrequency={{ zabbix_server_vmwareperffrequency }}
 VMwareCacheSize={{ zabbix_server_vmwarecachesize }}
 {% endif  %}
 
-{#{% if zabbix_short_version >= '30' %}#}
-{% if zabbix_version | version_compare('3.0', '>=') %}
+{% if zabbix_version is version_compare('3.0', '>=') %}
 ### Option: VMwareTimeout
 #       Specifies how many seconds vmware collector waits for response from VMware service.
 #
@@ -234,7 +229,7 @@ HousekeepingFrequency={{ zabbix_server_housekeepingfrequency }}
 #
 MaxHousekeeperDelete={{ zabbix_server_maxhousekeeperdelete }}
 
-{% if zabbix_version | version_compare('3.2', '<=') %}
+{% if zabbix_version is version_compare('3.2', '<=') %}
 ### option: senderfrequency
 #	how often zabbix will try to send unsent alerts (in seconds).
 #
@@ -263,7 +258,7 @@ StartDBSyncers={{ zabbix_server_startdbsyncers }}
 #
 HistoryCacheSize={{ zabbix_server_historycachesize }}
 
-{% if zabbix_version | version_compare('3.0', '>=') %}
+{% if zabbix_version is version_compare('3.0', '>=') %}
 ### Option: HistoryIndexCacheSize
 #       Size of history index cache, in bytes.
 #       Shared memory size for indexing history cache.
@@ -277,8 +272,7 @@ HistoryIndexCacheSize={{ zabbix_server_historyindexcachesize }}
 #
 TrendCacheSize={{ zabbix_server_trendcachesize }}
 
-{#{% if zabbix_short_version < 30 %}#}
-{% if zabbix_version | version_compare('3.0', '<') %}
+{% if zabbix_version is version_compare('3.0', '<') %}
     ### option: historytextcachesize
 #	size of text history cache, in bytes.
 #	shared memory size for storing character, text or log history data.
@@ -286,8 +280,7 @@ TrendCacheSize={{ zabbix_server_trendcachesize }}
 HistoryTextCacheSize={{ zabbix_server_historytextcachesize }}
 {% endif %}
 
-{#{% if zabbix_short_version >= 22 %}#}
-{% if zabbix_version | version_compare('2.2', '>=') %}
+{% if zabbix_version is version_compare('2.2', '>=') %}
 ### option: valuecachesize
 #	size of history value cache, in bytes.
 #	shared memory size for caching item history data requests
@@ -296,8 +289,7 @@ HistoryTextCacheSize={{ zabbix_server_historytextcachesize }}
 ValueCacheSize={{ zabbix_server_valuecachesize }}
 {% endif %}
 
-{#{% if zabbix_short_version <= 24 %}#}
-{% if zabbix_version | version_compare('2.4', '<') %}
+{% if zabbix_version is version_compare('2.4', '<') %}
 ### option: nodenoevents
 #	if set to '1' local events won't be sent to master node.
 #	this won't impact ability of this node to propagate events from its child nodes.
@@ -397,8 +389,7 @@ ProxyConfigFrequency={{ zabbix_server_proxyconfigfrequency }}
 #
 ProxyDataFrequency={{ zabbix_server_proxydatafrequency }}
 
-{#{% if zabbix_short_version >= 22 %}#}
-{% if zabbix_version | version_compare('2.2', '>=') %}
+{% if zabbix_version is version_compare('2.2', '>=') %}
 ### option: allowroot
 #	allow the server to run as 'root'. if disabled and the server is started by 'root', the server
 #	will try to switch to user 'zabbix' instead. has no effect if started under a regular user.
@@ -408,8 +399,7 @@ ProxyDataFrequency={{ zabbix_server_proxydatafrequency }}
 AllowRoot={{ zabbix_server_allowroot }}
 {% endif %}
 
-{#{% if zabbix_short_version >= 30 %}#}
-{% if zabbix_version | version_compare('3.0', '>=') %}
+{% if zabbix_version is version_compare('3.0', '>=') %}
 ### Option: User
 #       Drop privileges to a specific, existing user on the system.
 #       Only has effect if run as 'root' and AllowRoot is disabled.
@@ -423,8 +413,7 @@ User={{ zabbix_server_user }}
 #
 Include={{ zabbix_server_include }}
 
-{#{% if zabbix_short_version >= 30 %}#}
-{% if zabbix_version | version_compare('3.0', '>=') %}
+{% if zabbix_version is version_compare('3.0', '>=') %}
 ### Option: SSLCertLocation
 #       Location of SSL client certificates.
 #       This parameter is used only in web monitoring.
@@ -448,8 +437,7 @@ SSLCALocation={{ zabbix_server_sslcalocation }}
 {% endif %}
 
 ####### loadable modules #######
-{#{% if zabbix_short_version >= 22 %}#}
-{% if zabbix_version | version_compare('2.2', '>=') %}
+{% if zabbix_version is version_compare('2.2', '>=') %}
 ### option: loadmodulepath
 #	full path to location of server modules.
 #	default depends on compilation options.
@@ -467,8 +455,7 @@ LoadModulePath={{ zabbix_server_loadmodulepath }}
 LoadModule = {{ loadmodule }}
 {% endif %}
 
-{#{% if zabbix_short_version >= 30 %}#}
-{% if zabbix_version | version_compare('3.0', '>=') %}
+{% if zabbix_version is version_compare('3.0', '>=') %}
 ####### TLS-RELATED PARAMETERS #######
 
 ### Option: TLSCAFile

--- a/vars/zabbix.yml
+++ b/vars/zabbix.yml
@@ -1,0 +1,80 @@
+---
+
+sign_keys:
+  "34":
+    bionic:
+      sign_key: A14FE591
+    sonya:
+      sign_key: A14FE591
+    serena:
+      sign_key: A14FE591
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+    xenial:
+      sign_key: E709712C
+  "32":
+    sonya:
+      sign_key: 79EA5ED4
+    serena:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+    xenial:
+      sign_key: E709712C
+  "30":
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    stretch:
+      sign_key: A14FE591
+    trusty:
+      sign_key: 79EA5ED4
+    xenial:
+      sign_key: E709712C
+  "24":
+    wheezy:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    precise:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+  "22":
+    squeeze:
+      sign_key: 79EA5ED4
+    jessie:
+      sign_key: 79EA5ED4
+    precise:
+      sign_key: 79EA5ED4
+    trusty:
+      sign_key: 79EA5ED4
+    lucid:
+      sign_key: 79EA5ED4
+
+suse:
+  "openSUSE Leap":
+    "42":
+      name: server:monitoring
+      url: http://download.opensuse.org/repositories/server:/monitoring/openSUSE_Leap_{{ ansible_distribution_version }}/
+  "openSUSE":
+    "12":
+      name: server_monitoring
+      url: http://download.opensuse.org/repositories/server:/monitoring/openSUSE_{{ ansible_distribution_version }}
+  "SLES":
+    "11":
+      name: server_monitoring
+      url: http://download.opensuse.org/repositories/server:/monitoring/SLE_11_SP3/


### PR DESCRIPTION
This PR contains the following change:

* Support Debian 9;
* Use Debian 9 with Molecule instead of Debian 8;
* Removal of some warnings;
* Use Ansible 2.4 as minimum version;
* Fixed/Removed some deprecation warnings;
