### PR TITLE
move db creation file to delegated_dbhost

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -59,13 +59,32 @@
     - zabbix_version is version_compare('3.0', '>=')
     - zabbix_database_sqlload
 
+- name: "Retrieve database creation file"
+  fetch:
+    src: "{{ ls_output_create.stdout }}"
+    dest: /var/tmp/
+  become: no
+  when:
+    - zabbix_version is version_compare('3.0', '>=')
+    - zabbix_database_sqlload
+    - not done_file.stat.exists
+
+- name: "Send database creation file to {{ delegated_dbhost }}"
+  copy:
+    src: /var/tmp/{{ inventory_hostname }}/{{ ls_output_create.stdout }}
+    dest: /var/tmp/
+  when:
+    - zabbix_version is version_compare('3.0', '>=')
+    - zabbix_database_sqlload
+    - not done_file.stat.exists
+
 - name: "MySQL | Create database and import file >= 3.0"
   mysql_db:
     name: "{{ zabbix_server_dbname }}"
     encoding: "{{ zabbix_server_dbencoding }}"
     collation: "{{ zabbix_server_dbcollation }}"
     state: import
-    target: "{{ ls_output_create.stdout }}"
+    target: "/var/tmp/{{ inventory_hostname }}/{{ ls_output_create.stdout }}"
   when:
     - zabbix_version is version_compare('3.0', '>=')
     - zabbix_database_sqlload


### PR DESCRIPTION
**Description of PR**
<!--- Describe what the PR holds -->
This change will retrieve the file used to initialize the database and then copy it to the `delegated_dbhost` before loading it.  it intentionally does not remove the file afterward, in case something goes wrong and the file needs to be re-imported. it also only executes for the series of conditions around zabbix `>=3.0` and was only tested on Ubuntu.

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
it fixes #96.
