### PR TITLE
support custom role for local tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@
 
 zabbix_version: 3.4
 zabbix_repo: zabbix
+zabbix_include_custom_role: False
+zabbix_custom_role_name: 
 
 zabbix_repo_yum:
   - name: zabbix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,12 @@
     - init
     - config
 
+- name: include custom role
+  include_role: 
+    name: "{{ zabbix_custom_role_name }}"
+  when: zabbix_include_custom_role
+  tags: always
+
 - name: "Create include dir zabbix-server"
   file:
     path: "{{ zabbix_server_include }}"


### PR DESCRIPTION
**Description of PR**
I wanted to include custom external and alert scripts without polluting the upstream role. This uses `zabbix_include_custom_role` (default: `False`) to include `zabbix_custom_role_name`, which can do other things (like install scripts) prior to the restart of the server process.

**Type of change**
Feature Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
