### PR TITLE
Debian fping location

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@
 
 zabbix_version: 3.4
 zabbix_repo: zabbix
+zabbix_include_custom_role: False
+zabbix_custom_role_name: 
 
 zabbix_repo_yum:
   - name: zabbix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,12 @@
     - init
     - config
 
+- name: include custom role
+  include_role: 
+    name: "{{ zabbix_custom_role_name }}"
+  when: zabbix_include_custom_role
+  tags: always
+
 - name: "Create include dir zabbix-server"
   file:
     path: "{{ zabbix_server_include }}"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,3 +2,5 @@
 apache_user: www-data
 apache_group: www-data
 apache_log: apache2
+zabbix_server_fpinglocation: /usr/bin/fping
+zabbix_server_fping6location: /usr/bin/fping6


### PR DESCRIPTION
**Description of PR**
Debian/Ubuntu have `fping` and `fping6` in `/usr/bin` and not `/usr/sbin`. The result of the default installation is that Zabbix refuses to execute any ICMP check because it can't find the binaries. Those checks quietly go into `Not Supported` status.

This PR sets the location in `Debian.yml` so that people don't have to override it locally.

**Type of change**
Bugfix Pull Request
