### PR TITLE
Adding login parameters to database import task

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -61,6 +61,11 @@
 
 - name: "MySQL | Create database and import file >= 3.0"
   mysql_db:
+    login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"
+    login_user: "{{ zabbix_server_mysql_login_user | default(omit) }}"
+    login_password: "{{ zabbix_server_mysql_login_password | default(omit) }}"
+    login_port: "{{ zabbix_server_mysql_login_port | default(omit) }}"
+    login_unix_socket: "{{ zabbix_server_mysql_login_unix_socket | default(omit) }}"
     name: "{{ zabbix_server_dbname }}"
     encoding: "{{ zabbix_server_dbencoding }}"
     collation: "{{ zabbix_server_dbcollation }}"


### PR DESCRIPTION
**Description of PR**
Role sometimes fails because there are no credentials to login to the database for importing the dump.
Added `login_` parameters for `mysql_db` module.

**Type of change**

Bugfix Pull Request


