### PR TITLE
Fixes Deprecation Warnings for Ansible 2.7 to prepare.yml

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,23 +4,21 @@
   pre_tasks:
     - name: "Installing packages"
       yum:
-        name: "{{ item }}"
+        name:
+          - net-tools
+          - which
+          - libselinux-python
         state: present
-      with_items:
-        - net-tools
-        - which
-        - libselinux-python
       register: installation_dependencies
       when:
         - ansible_os_family == 'RedHat'
 
     - name: "Installing which on NON-CentOS"
       apt:
-        name: "{{ item }}"
+        name:
+          - net-tools
+          - apt-utils
         state: present
-      with_items:
-        - net-tools
-        - apt-utils
       when:
         - ansible_os_family != 'RedHat'
 


### PR DESCRIPTION
**Description of PR**
Fixes Deprecation warnings with the upgrade to Ansible 2.7.  
Specifically it removes the loop that is no longer needed with the upgrade.

**Type of change**
Feature Pull Request

**Fixes an issue**
Fixes Deprecation Warning
```[DEPRECATION WARNING]: Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying name: {{ item }}, please use name: [u'snappy', u'snappy- devel', u'zlib', u'zlib-devel', u'hwloc', u'gcc', u'lzo', u'lzo-devel', u'python', u'make'] and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.```
