### PR TITLE
Fix Deprecation warning associated with apt loops in Debian.yml

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -80,11 +80,10 @@
 
 - name: "Debian | Install Mysql Client package"
   apt:
-    name: "{{ item }}"
+    name:
+      - mysql-client
+      - python-mysqldb
     state: present
-  with_items:
-    - mysql-client
-    - python-mysqldb
   when:
     - zabbix_server_database == 'mysql'
   tags:


### PR DESCRIPTION
Description of PR
Fixes Deprecation warnings with the upgrade to Ansible 2.7.
Specifically it removes the loop that is no longer needed with the upgrade.

Type of change
Feature Pull Request

Fixes an issue
Fixes Deprecation Warning
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying name: {{ item }}, please use name: [u'snappy', u'snappy- devel', u'zlib', u'zlib-devel', u'hwloc', u'gcc', u'lzo', u'lzo-devel', u'python', u'make'] and remove the loop. This feature will be removed in version 2.11. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.