### PR TITLE
Pre 4.0 config

### DIFF
--- a/templates/zabbix_server.conf.j2
+++ b/templates/zabbix_server.conf.j2
@@ -122,7 +122,7 @@ HistoryStorageURL={{ zabbix_server_historystorageurl }}
 # Default:
 HistoryStorageTypes={{ zabbix_server_historystoragetypes }}
 
-{% if zabbix_version is ('4.0', '>=') %}
+{% if zabbix_version is version('4.0', '>=') %}
 ### Option: HistoryStorageDateIndex
 #	Enable preprocessing of history values in history storage to store values in different indices based on date.
 #	0 - disable
@@ -143,7 +143,7 @@ HistoryStorageDateIndex={{ zabbix_server_historystoragedateindex }}
 ExportDir={{ zabbix_server_exportdir }}
 {% endif %}
 
-{% if zabbix_version is ('4.0', '>=') %}
+{% if zabbix_version is version('4.0', '>=') %}
 ### Option: ExportFileSize
 #	Maximum size per export file in bytes.
 #	Only used for rotation if ExportDir is set.

--- a/templates/zabbix_server.conf.j2
+++ b/templates/zabbix_server.conf.j2
@@ -122,6 +122,7 @@ HistoryStorageURL={{ zabbix_server_historystorageurl }}
 # Default:
 HistoryStorageTypes={{ zabbix_server_historystoragetypes }}
 
+{% if zabbix_version is ('4.0', '>=') %}
 ### Option: HistoryStorageDateIndex
 #	Enable preprocessing of history values in history storage to store values in different indices based on date.
 #	0 - disable
@@ -130,6 +131,7 @@ HistoryStorageTypes={{ zabbix_server_historystoragetypes }}
 # Mandatory: no
 # Default:
 HistoryStorageDateIndex={{ zabbix_server_historystoragedateindex }}
+{% endif %}
 
 ### Option: ExportDir
 #	Directory for real time export of events, history and trends in newline delimited JSON format.
@@ -141,6 +143,7 @@ HistoryStorageDateIndex={{ zabbix_server_historystoragedateindex }}
 ExportDir={{ zabbix_server_exportdir }}
 {% endif %}
 
+{% if zabbix_version is ('4.0', '>=') %}
 ### Option: ExportFileSize
 #	Maximum size per export file in bytes.
 #	Only used for rotation if ExportDir is set.
@@ -149,7 +152,7 @@ ExportDir={{ zabbix_server_exportdir }}
 # Range: 1M-1G
 # Default:
 ExportFileSize={{ zabbix_server_exportfilesize }}
-
+{% endif %}
 ############ advanced parameters ################
 
 ### option: startpollers


### PR DESCRIPTION
When using zabbix-server < 4.0 
the configuration options ExportFileSize and HistoryStorageDateIndex is not yet implemented and the service fails to start. 
