### PR TITLE
Add install_recommends option to the apt-get install of zabbix-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_server_dbpassword`: The database user password which is used by the Zabbix Server.
 * `zabbix_server_dbport`: The database port which is used by the Zabbix Server.
 * `zabbix_server_database_creation`: True / False. When you don't want to create the database including user, you can set it to False.
+* `zabbix_server_install_recommends`: True / False. False does not install the recommended packages that come with the zabbix-server install. Default true
+* `zabbix_server_install_database_client`: True / False. False does not install database client. Default true
 * `zabbix_server_database_sqlload`:True / False. When you don't want to load the sql files into the database, you can set it to False.
 * `zabbix_server_dbencoding`: The encoding for the MySQL database. Default set to `utf8`
 * `zabbix_server_dbcollation`: The collation for the MySQL database. Default set to `utf8_bin`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,8 @@ zabbix_version: 4.0
 zabbix_repo: zabbix
 
 zabbix_server_package_state: present
+zabbix_server_install_recommends: True
+zabbix_server_install_database_client: True
 
 zabbix_repo_yum:
   - name: zabbix

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -64,6 +64,7 @@
     state: "{{ zabbix_server_package_state }}"
     update_cache: yes
     cache_valid_time: 0
+    install_recommends: "{{ zabbix_server_install_recommends }}"
   tags:
     - zabbix-server
     - init
@@ -86,6 +87,7 @@
     state: present
   when:
     - zabbix_server_database == 'mysql'
+    - zabbix_server_install_database_client == true
   tags:
     - zabbix-server
     - init
@@ -97,6 +99,7 @@
     state: present
   when:
     - zabbix_server_database == 'pgsql'
+    - zabbix_server_install_database_client == true
   tags:
     - zabbix-server
     - init


### PR DESCRIPTION
Add option to not install database client

**Description of PR**
- Adds option to not install recommended packages in the `apt-get install zabbix-server-<db>`
- Adds option to not install database client
- Default variables leaves things as is with the option to change

**Type of change**
Feature Pull Request

**Fixes an issue**
If Postgresql was already installed on the server it would install a different version over it. This solves that problem.
