### PR TITLE
Fix for: unable to install older releases of zabbix-server

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -90,7 +90,7 @@
     - not done_file.stat.exists
 
 - name: "Get the correct path for the SQL files < 3.0"
-  shell: ls -1 {{ datafiles_path }}/create/{{ item }}.sql*
+  shell: ls -1 {{ datafiles_path }}/{{ mysql_create_dir }}{{ item }}.sql*
   changed_when: False
   register: ls_output_schema
   with_items:

--- a/templates/zabbix_server.conf.j2
+++ b/templates/zabbix_server.conf.j2
@@ -14,6 +14,7 @@ ListenPort={{ zabbix_server_listenport }}
 SourceIP={{ zabbix_server_sourceip }}
 {% endif %}
 
+{% if zabbix_version is version('3.0', '>=') %}
 ### Option: LogType
 #	Specifies where log messages are written to:
 #		system  - syslog
@@ -23,6 +24,7 @@ SourceIP={{ zabbix_server_sourceip }}
 # Mandatory: no
 # Default:
 LogType={{ zabbix_server_logtype }}
+{% endif %}
 
 ### option: logfile
 #	name of log file.
@@ -54,7 +56,9 @@ DebugLevel={{ zabbix_server_debuglevel }}
 # Default:
 # SocketDir=/tmp
 
+{% if zabbix_version is version('3.4', '>=') %}
 SocketDir={{ zabbix_server_socketdir }}
+{% endif %}
 
 ### option: pidfile
 #	name of pid file.
@@ -115,12 +119,14 @@ DBPort={{ zabbix_server_dbport }}
 HistoryStorageURL={{ zabbix_server_historystorageurl }}
 {% endif %}
 
+{% if zabbix_version is version('3.4', '>=') %}
 ### Option: HistoryStorageTypes
 #	Comma separated list of value types to be sent to the history storage.
 #
 # Mandatory: no
 # Default:
 HistoryStorageTypes={{ zabbix_server_historystoragetypes }}
+{% endif %}
 
 {% if zabbix_version is version('4.0', '>=') %}
 ### Option: HistoryStorageDateIndex
@@ -133,6 +139,7 @@ HistoryStorageTypes={{ zabbix_server_historystoragetypes }}
 HistoryStorageDateIndex={{ zabbix_server_historystoragedateindex }}
 {% endif %}
 
+{% if zabbix_version is version('4.0', '>=') %}
 ### Option: ExportDir
 #	Directory for real time export of events, history and trends in newline delimited JSON format.
 #	If set, enables real time export.
@@ -141,6 +148,7 @@ HistoryStorageDateIndex={{ zabbix_server_historystoragedateindex }}
 # Default:
 {% if zabbix_server_exportdir is defined and zabbix_server_exportdir %}
 ExportDir={{ zabbix_server_exportdir }}
+{% endif %}
 {% endif %}
 
 {% if zabbix_version is version('4.0', '>=') %}

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,3 +2,5 @@
 apache_user: www-data
 apache_group: www-data
 apache_log: apache2
+
+mysql_create_dir: ''

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,3 +2,5 @@
 apache_user: apache
 apache_group: apache
 apache_log: httpd
+
+mysql_create_dir: create/


### PR DESCRIPTION
**Description of PR**
This PR contains the following change:

* Loading of sql files failed when using Zabbix 2.2. Debian/Ubuntu doesn't use the `create` folder, RedHat does;
* Added a version check in the zabbix_server.d.conf so Zabbix will not fail if it doesn't understand the property if that isn't part of the version;

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
Fixes #128