### PR TITLE
fix deprecation warning in ansible 2.4

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,22 +5,22 @@
   include_vars: "{{ ansible_os_family }}.yml"
 
 - name: "Install the correct repository"
-  include: "RedHat.yml"
+  include_tasks: "RedHat.yml"
   when:
     - ansible_os_family == "RedHat"
 
 - name: "Install the correct repository"
-  include: "Debian.yml"
+  include_tasks: "Debian.yml"
   when:
     - ansible_os_family == "Debian"
 
 - name: "Installing the postgresql database"
-  include: "postgresql.yml"
+  include_tasks: "postgresql.yml"
   when:
     - zabbix_server_database_long == "postgresql"
 
 - name: "Installing the mysql database"
-  include: "mysql.yml"
+  include_tasks: "mysql.yml"
   when:
     - zabbix_server_database_long == "mysql"
 


### PR DESCRIPTION
**Description of PR**
The use of 'include' for tasks has been deprecated. Use 'import_tasks' for static inclusions or 'include_tasks' for dynamic inclusions.


**Type of change**
micro fix

