### PR TITLE
modified placement of seboolean variables

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -115,8 +115,7 @@
 
 - name: "RedHat | Enable httpd_can_connect_zabbix SELinux boolean"
   seboolean:
-    name:
-      - httpd_can_connect_zabbix
+    name: httpd_can_connect_zabbix
     state: yes
     persistent: yes
   when:
@@ -126,8 +125,7 @@
 
 - name: "RedHat | Enable zabbix_can_network SELinux boolean"
   seboolean:
-    name:
-      - zabbix_can_network
+    name: zabbix_can_network
     state: yes
     persistent: yes
   when:


### PR DESCRIPTION
**Description of PR**
Modifies seboolean tasks within RedHat.yml tasks placing the name of the boolean variable on the same line as `name:`.  

**Type of change**

Bugfix Pull Request

**Fixes an issue**

Resolves issue #134 
