### PR TITLE
fix installation when zabbix_repo="other"

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -5,7 +5,7 @@
   set_fact:
     zabbix_server_package: "zabbix-server-{{ zabbix_server_database }}"
   when:
-    - zabbix_repo == "zabbix"
+    - zabbix_repo == "zabbix" or zabbix_repo == "other"
   tags:
     - zabbix-server
 
@@ -50,6 +50,8 @@
     gpgkey: "{{ item.gpgkey }}"
     state: "{{ item.state | default('present') }}"
   with_items: "{{ zabbix_repo_yum }}"
+  when:
+    - zabbix_repo == "zabbix"
   tags:
     - zabbix-server
 


### PR DESCRIPTION
**Description of PR**
When you set `zabbix_repo="other"`, there's no need to install the basic repo file.
In order for the installation to succeed, the fact `zabbix_server_package` must also be configured when choosing `zabbix_repo="other"`.

**Type of change**
Bugfix Pull Request