### PR TITLE
Fix Zabbix installation on Bionic

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -64,6 +64,23 @@
   tags:
     - skip_ansible_lint
 
+# On certain 18.04 images, such as docker or lxc, dpkg is configured not to
+# install files into paths /usr/share/doc/*
+# Since this is where Zabbix installs its database schemas, we need to allow
+# files to be installed to /usr/share/doc/zabbix*
+- name: Check for the dpkg exclude line
+  command: grep -F 'path-exclude=/usr/share/doc/*' /etc/dpkg/dpkg.cfg.d/excludes
+  register: dpkg_exclude_line
+  failed_when: false
+  changed_when: false
+
+- name: Allow Zabbix dpkg installs to /usr/share/doc/zabbix*
+  lineinfile:
+    path: /etc/dpkg/dpkg.cfg.d/excludes
+    line: 'path-include=/usr/share/doc/zabbix*'
+  when:
+    - dpkg_exclude_line.rc == 0
+
 - name: "Debian | Installing zabbix-server-{{ zabbix_server_database }}"
   apt:
     pkg: zabbix-server-{{ zabbix_server_database }}


### PR DESCRIPTION
On bionic, the database schemas are not installed on containerized
systems such as LXC or docker images because they contain a dpkg
configuration which excludes file installation to /usr/share/doc/*.

This breaks the role because dpkg filters the Zabbix database schemas
that are typically installed to this path.

**Type of change**
Bugfix Pull Request

**Fixes an issue**
On a bionic install in affected environments, the following is observed:
```
# dpkg -S /usr/share/doc/zabbix-server-mysql/create.sql.gz
zabbix-server-mysql: /usr/share/doc/zabbix-server-mysql/create.sql.gz
# ls /usr/share/doc/zabbix-server-mysql/create.sql.gz
ls: cannot access '/usr/share/doc/zabbix-server-mysql/create.sql.gz': No such file or directory
# ls /usr/share/doc/zabbix-server-mysql
changelog.Debian.gz  copyright
```

This causes the task `zabbix_server : Get the file for create.sql >= 3.0` to fail due to the error `ls: cannot access '/usr/share/doc/zabbix-server-mysql/create.sq*': No such file or directory`

The reason the file is not present is because dpkg is configured to filter installations to `/usr/share/doc/*` in `/etc/dpkg/dpkg.cfg.d/excludes`, specifically with the line: 
```
# Drop all documentation ...
path-exclude=/usr/share/doc/*
```

To fix this issue, we can drop the following line in the file before installing the `zabbix-server-{mysql,pgsql}` packages:
```
path-include=/usr/share/doc/zabbix*
```
, which will allow the Zabbix package to install the schemas as usual to these paths.

Please see upstream bug https://support.zabbix.com/browse/ZBX-14820 for more information.