### PR TITLE
Fix typo on config

### DIFF
--- a/templates/zabbix_server.conf.j2
+++ b/templates/zabbix_server.conf.j2
@@ -284,7 +284,7 @@ StartSNMPTrapper={{ zabbix_server_startsnmptrapper }}
 #	trapper will listen on all network interfaces if this parameter is missing.
 #
 {% if zabbix_server_listenip is defined and zabbix_server_listenip %}
-ListenIp={{ zabbix_server_listenip }}
+ListenIP={{ zabbix_server_listenip }}
 {% endif %}
 
 ### option: housekeepingfrequency


### PR DESCRIPTION
**Description of PR**
There is no ListenIp option in zabbix config, it is ListenI**P**

This fixes this typo to avoid folowing error on startup:
```
unknown parameter "ListenIp" in config file "/etc/zabbix/zabbix_server.conf", line 234
```

**Type of change**
Bugfix Pull Request
