### PR TITLE
Fixed installation on Debian 10 (buster)

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -118,6 +118,24 @@
   when:
     - zabbix_server_database == 'mysql'
     - zabbix_server_install_database_client
+    - ansible_distribution_release != "buster"
+  tags:
+    - zabbix-server
+    - init
+    - database
+
+- name: "Debian 10 | Install Mysql Client package"
+  apt:
+    name:
+      - mariadb-client
+      - "{{ zabbix_python_prefix }}-mysqldb"
+    state: present
+  register: zabbix_server_dependencies_installed
+  until: zabbix_server_dependencies_installed is succeeded
+  when:
+    - zabbix_server_database == 'mysql'
+    - zabbix_server_install_database_client
+    - ansible_distribution_release == "buster"
   tags:
     - zabbix-server
     - init

--- a/vars/zabbix.yml
+++ b/vars/zabbix.yml
@@ -10,6 +10,8 @@ sign_keys:
       sign_key: A14FE591
     stretch:
       sign_key: A14FE591
+    buster:
+      sign_key: 79EA5ED4
     wheezy:
       sign_key: 79EA5ED4
     jessie:
@@ -27,6 +29,8 @@ sign_keys:
       sign_key: A14FE591
     stretch:
       sign_key: A14FE591
+    buster:
+      sign_key: 79EA5ED4
     wheezy:
       sign_key: 79EA5ED4
     jessie:
@@ -44,6 +48,8 @@ sign_keys:
       sign_key: A14FE591
     stretch:
       sign_key: A14FE591
+    buster:
+      sign_key: 79EA5ED4
     wheezy:
       sign_key: 79EA5ED4
     jessie:
@@ -59,6 +65,8 @@ sign_keys:
       sign_key: 79EA5ED4
     stretch:
       sign_key: A14FE591
+    buster:
+      sign_key: 79EA5ED4
     wheezy:
       sign_key: 79EA5ED4
     jessie:
@@ -74,6 +82,8 @@ sign_keys:
       sign_key: 79EA5ED4
     stretch:
       sign_key: A14FE591
+    buster:
+      sign_key: 79EA5ED4
     trusty:
       sign_key: 79EA5ED4
     xenial:


### PR DESCRIPTION
**Description of PR**
I've added support for Debian 10. It does not have `mysql-client`. 

**Type of change**
Feature Pull Request

**Fixes an issue**

