### PR TITLE
Workaround for importing create.sql.gz issue on Debian 10

### DIFF
--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -59,6 +59,20 @@
     - zabbix_version is version_compare('3.0', '>=')
     - zabbix_database_sqlload
 
+- name: "MySQL | Disable InnoDB Strict Mode"
+  mysql_variables:
+    variable: innodb_strict_mode
+    value: 0
+  when:
+    - zabbix_version is version_compare('3.0', '>=')
+    - zabbix_database_sqlload
+    - not done_file.stat.exists
+    - ansible_distribution_release == "buster"
+  delegate_to: "{{ delegated_dbhost }}"
+  tags:
+    - zabbix-server
+    - database
+
 - name: "MySQL | Create database and import file >= 3.0"
   mysql_db:
     login_host: "{{ zabbix_server_mysql_login_host | default(omit) }}"


### PR DESCRIPTION
**Description of PR**
Debian 10 comes with MariaDB 10.3.17:
```
~$ cat /etc/debian_version 
10.1
~$ mysql -V
mysql  Ver 15.1 Distrib 10.3.17-MariaDB, for debian-linux-gnu (x86_64) using readline 5.2
```
When importing a schema into a database, a problem arises:
```
ERROR 1118 (42000) at line 1278: Row size too large (> 8126). Changing some columns to TEXT or BLOB may help. In current row format, BLOB prefix of 0 bytes is stored inline.
```
Details can be found here: https://support.zabbix.com/browse/ZBX-16465

As a workaround we can disable InnoDB strict mode before importing.

**Type of change**
Bugfix Pull Request

**Fixes an issue**
