### PR TITLE
Replaced version_compare

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -10,13 +10,13 @@
       - "http://repo.zabbix.com/zabbix/{{ zabbix_version }}/{{ ansible_distribution.lower() }}/"
       - "{{ ansible_distribution_release }}"
       - "main"
-    zabbix_python_prefix: "python{% if ansible_python_version | version_compare('3', '>=') %}3{% endif %}"
+    zabbix_python_prefix: "python{% if ansible_python_version is version('3', '>=') %}3{% endif %}"
 
 - name: "Debian | Set some facts"
   set_fact:
     datafiles_path: /usr/share/zabbix-server-{{ zabbix_server_database }}
   when:
-    - zabbix_version is version_compare('3.0', '<')
+    - zabbix_version is version('3.0', '<')
   tags:
     - zabbix-server
     - init
@@ -26,7 +26,7 @@
   set_fact:
     datafiles_path: /usr/share/doc/zabbix-server-{{ zabbix_server_database }}
   when:
-    - zabbix_version is version_compare('3.0', '>=')
+    - zabbix_version is version('3.0', '>=')
   tags:
     - zabbix-server
     - init

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -29,7 +29,7 @@
   set_fact:
     datafiles_path: "/usr/share/doc/zabbix-server-{{ zabbix_server_database }}-{{ zabbix_version }}*"
   when:
-    - zabbix_version is version_compare('3.0', '<')
+    - zabbix_version is version('3.0', '<')
   tags:
     - zabbix-server
 
@@ -37,7 +37,7 @@
   set_fact:
     datafiles_path: "/usr/share/doc/zabbix-server-{{ zabbix_server_database }}-{{ zabbix_version }}*"
   when:
-    - zabbix_version is version_compare('3.0', '>=')
+    - zabbix_version is version('3.0', '>=')
   tags:
     - zabbix-server
 

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -44,7 +44,7 @@
   shell: ls -1 {{ datafiles_path }}/create.sq*
   changed_when: False
   when:
-    - zabbix_version is version_compare('3.0', '>=')
+    - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload
   register: ls_output_create
   tags:
@@ -56,7 +56,7 @@
     path: /etc/zabbix/create.done
   register: done_file
   when:
-    - zabbix_version is version_compare('3.0', '>=')
+    - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload
 
 - name: "MySQL | Disable InnoDB Strict Mode"
@@ -64,7 +64,7 @@
     variable: innodb_strict_mode
     value: 0
   when:
-    - zabbix_version is version_compare('3.0', '>=')
+    - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload
     - not done_file.stat.exists
     - ansible_distribution_release == "buster"
@@ -86,7 +86,7 @@
     state: import
     target: "{{ ls_output_create.stdout }}"
   when:
-    - zabbix_version is version_compare('3.0', '>=')
+    - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload
     - not done_file.stat.exists
   delegate_to: "{{ delegated_dbhost }}"
@@ -99,7 +99,7 @@
     path: /etc/zabbix/create.done
     state: touch
   when:
-    - zabbix_version is version_compare('3.0', '>=')
+    - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload
     - not done_file.stat.exists
 
@@ -112,7 +112,7 @@
     - images
     - data
   when:
-    - zabbix_version is version_compare('3.0', '<')
+    - zabbix_version is version('3.0', '<')
     - zabbix_database_sqlload
   tags:
     - zabbix-server
@@ -127,7 +127,7 @@
     - images
     - data
   when:
-    - zabbix_version is version_compare('3.0', '<')
+    - zabbix_version is version('3.0', '<')
     - zabbix_database_sqlload
   tags:
     - zabbix-server
@@ -138,7 +138,7 @@
     sql_files_executed: "{{ sql_files_executed | default({}) | combine({item.item: item.stat}) }}"
   with_items: "{{ done_files.results }}"
   when:
-    - zabbix_version is version_compare('3.0', '<')
+    - zabbix_version is version('3.0', '<')
     - zabbix_database_sqlload
   tags:
     - zabbix-server
@@ -153,7 +153,7 @@
     target: "{{ item.stdout }}"
   with_items: "{{ ls_output_schema.results }}"
   when:
-    - zabbix_version is version_compare('3.0', '<')
+    - zabbix_version is version('3.0', '<')
     - zabbix_database_sqlload
     - not sql_files_executed[item.item].exists
   delegate_to: "{{ delegated_dbhost }}"
@@ -170,7 +170,7 @@
     - images
     - data
   when:
-    - zabbix_version is version_compare('3.0', '<')
+    - zabbix_version is version('3.0', '<')
     - zabbix_database_sqlload
     - not sql_files_executed[item].exists
   tags:

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -76,7 +76,7 @@
   environment:
     PGPASSWORD: '{{ zabbix_server_dbpassword }}'
   when:
-    - zabbix_version is version_compare('3.0', '>=')
+    - zabbix_version is version('3.0', '>=')
     - zabbix_database_sqlload
   tags:
     - zabbix-server
@@ -87,7 +87,7 @@
   register: datafiles_path_full
   changed_when: False
   when:
-    - (zabbix_version is version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
+    - (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - skip_ansible_lint
 
@@ -96,13 +96,13 @@
     path: "{{ datafiles_path_full.stdout }}/create"
   register: create_dir_or_not
   when:
-    - (zabbix_version is version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
+    - (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
 
 - name: "Set fact"
   set_fact:
     datafiles_path: "{{ datafiles_path }}/create"
   when:
-    - (zabbix_version is version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
+    - (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
     - create_dir_or_not.stat.isdir is defined and create_dir_or_not.stat.isdir
     - create_dir_or_not.stat.exists
 
@@ -121,7 +121,7 @@
   environment:
     PGPASSWORD: '{{ zabbix_server_dbpassword }}'
   when:
-    - (zabbix_version is version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
+    - (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server
     - database
@@ -139,7 +139,7 @@
     warn: no
   environment:
     PGPASSWORD: '{{ zabbix_server_dbpassword }}'
-  when: (zabbix_version is version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
+  when: (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server
     - database
@@ -157,7 +157,7 @@
     warn: no
   environment:
     PGPASSWORD: '{{ zabbix_server_dbpassword }}'
-  when: (zabbix_version is version_compare('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
+  when: (zabbix_version is version('3.0', '<') and zabbix_database_sqlload) or (zabbix_repo == "epel" and zabbix_database_sqlload)
   tags:
     - zabbix-server
     - database

--- a/templates/zabbix_server.conf.j2
+++ b/templates/zabbix_server.conf.j2
@@ -14,7 +14,7 @@ ListenPort={{ zabbix_server_listenport }}
 SourceIP={{ zabbix_server_sourceip }}
 {% endif %}
 
-{% if zabbix_version is version_compare('3.0', '>=') %}
+{% if zabbix_version is version('3.0', '>=') %}
 ### Option: LogType
 #	Specifies where log messages are written to:
 #		system  - syslog
@@ -56,7 +56,7 @@ DebugLevel={{ zabbix_server_debuglevel }}
 # Default:
 # SocketDir=/tmp
 
-{% if zabbix_version is version_compare('3.4', '>=') %}
+{% if zabbix_version is version('3.4', '>=') %}
 SocketDir={{ zabbix_server_socketdir }}
 {% endif %}
 
@@ -119,7 +119,7 @@ DBPort={{ zabbix_server_dbport }}
 HistoryStorageURL={{ zabbix_server_historystorageurl }}
 {% endif %}
 
-{% if zabbix_version is version_compare('3.4', '>=') %}
+{% if zabbix_version is version('3.4', '>=') %}
 ### Option: HistoryStorageTypes
 #	Comma separated list of value types to be sent to the history storage.
 #
@@ -128,7 +128,7 @@ HistoryStorageURL={{ zabbix_server_historystorageurl }}
 HistoryStorageTypes={{ zabbix_server_historystoragetypes }}
 {% endif %}
 
-{% if zabbix_version is version_compare('4.0', '>=') %}
+{% if zabbix_version is version('4.0', '>=') %}
 ### Option: HistoryStorageDateIndex
 #	Enable preprocessing of history values in history storage to store values in different indices based on date.
 #	0 - disable
@@ -139,7 +139,7 @@ HistoryStorageTypes={{ zabbix_server_historystoragetypes }}
 HistoryStorageDateIndex={{ zabbix_server_historystoragedateindex }}
 {% endif %}
 
-{% if zabbix_version is version_compare('4.0', '>=') %}
+{% if zabbix_version is version('4.0', '>=') %}
 ### Option: ExportDir
 #	Directory for real time export of events, history and trends in newline delimited JSON format.
 #	If set, enables real time export.
@@ -151,7 +151,7 @@ ExportDir={{ zabbix_server_exportdir }}
 {% endif %}
 {% endif %}
 
-{% if zabbix_version is version_compare('4.0', '>=') %}
+{% if zabbix_version is version('4.0', '>=') %}
 ### Option: ExportFileSize
 #	Maximum size per export file in bytes.
 #	Only used for rotation if ExportDir is set.
@@ -200,7 +200,7 @@ StartDiscoverers={{ zabbix_server_startdiscoverers }}
 #
 StartHTTPPollers={{ zabbix_server_starthttppollers }}
 
-{% if zabbix_version is version_compare('2.0', '>=') %}
+{% if zabbix_version is version('2.0', '>=') %}
 ### option: starttimers
 #	number of pre-forked instances of timers.
 #	timers process time-based trigger functions and maintenance periods.
@@ -209,7 +209,7 @@ StartHTTPPollers={{ zabbix_server_starthttppollers }}
 StartTimers={{ zabbix_server_starttimers }}
 {% endif %}
 
-{% if zabbix_version is version_compare('3.0', '>=') %}
+{% if zabbix_version is version('3.0', '>=') %}
 ### Option: StartEscalators
 #   Number of pre-forked instances of escalators.
 #
@@ -234,7 +234,7 @@ JavaGatewayPort={{ zabbix_server_javagatewayport }}
 StartJavaPollers={{ zabbix_server_startjavapollers }}
 {% endif  %}
 
-{% if zabbix_version is version_compare('2.2', '>=') %}
+{% if zabbix_version is version('2.2', '>=') %}
 ### option: startvmwarecollectors
 #	number of pre-forked vmware collector instances.
 #
@@ -245,7 +245,7 @@ StartVMwareCollectors={{ zabbix_server_startvmwarecollectors }}
 #
 VMwareFrequency={{ zabbix_server_vmwarefrequency }}
 
-{% if zabbix_version is version_compare('3.0', '>=') %}
+{% if zabbix_version is version('3.0', '>=') %}
 ### Option: VMwarePerfFrequency
 #       How often Zabbix will connect to VMware service to obtain performance data.
 #
@@ -261,7 +261,7 @@ VMwarePerfFrequency={{ zabbix_server_vmwareperffrequency }}
 VMwareCacheSize={{ zabbix_server_vmwarecachesize }}
 {% endif  %}
 
-{% if zabbix_version is version_compare('3.0', '>=') %}
+{% if zabbix_version is version('3.0', '>=') %}
 ### Option: VMwareTimeout
 #       Specifies how many seconds vmware collector waits for response from VMware service.
 #
@@ -309,7 +309,7 @@ HousekeepingFrequency={{ zabbix_server_housekeepingfrequency }}
 #
 MaxHousekeeperDelete={{ zabbix_server_maxhousekeeperdelete }}
 
-{% if zabbix_version is version_compare('3.2', '<=') %}
+{% if zabbix_version is version('3.2', '<=') %}
 ### option: senderfrequency
 #	how often zabbix will try to send unsent alerts (in seconds).
 #
@@ -338,7 +338,7 @@ StartDBSyncers={{ zabbix_server_startdbsyncers }}
 #
 HistoryCacheSize={{ zabbix_server_historycachesize }}
 
-{% if zabbix_version is version_compare('3.0', '>=') %}
+{% if zabbix_version is version('3.0', '>=') %}
 ### Option: HistoryIndexCacheSize
 #       Size of history index cache, in bytes.
 #       Shared memory size for indexing history cache.
@@ -352,7 +352,7 @@ HistoryIndexCacheSize={{ zabbix_server_historyindexcachesize }}
 #
 TrendCacheSize={{ zabbix_server_trendcachesize }}
 
-{% if zabbix_version is version_compare('3.0', '<') %}
+{% if zabbix_version is version('3.0', '<') %}
     ### option: historytextcachesize
 #	size of text history cache, in bytes.
 #	shared memory size for storing character, text or log history data.
@@ -360,7 +360,7 @@ TrendCacheSize={{ zabbix_server_trendcachesize }}
 HistoryTextCacheSize={{ zabbix_server_historytextcachesize }}
 {% endif %}
 
-{% if zabbix_version is version_compare('2.2', '>=') %}
+{% if zabbix_version is version('2.2', '>=') %}
 ### option: valuecachesize
 #	size of history value cache, in bytes.
 #	shared memory size for caching item history data requests
@@ -369,7 +369,7 @@ HistoryTextCacheSize={{ zabbix_server_historytextcachesize }}
 ValueCacheSize={{ zabbix_server_valuecachesize }}
 {% endif %}
 
-{% if zabbix_version is version_compare('2.4', '<') %}
+{% if zabbix_version is version('2.4', '<') %}
 ### option: nodenoevents
 #	if set to '1' local events won't be sent to master node.
 #	this won't impact ability of this node to propagate events from its child nodes.
@@ -469,7 +469,7 @@ ProxyConfigFrequency={{ zabbix_server_proxyconfigfrequency }}
 #
 ProxyDataFrequency={{ zabbix_server_proxydatafrequency }}
 
-{% if zabbix_version is version_compare('2.2', '>=') %}
+{% if zabbix_version is version('2.2', '>=') %}
 ### option: allowroot
 #	allow the server to run as 'root'. if disabled and the server is started by 'root', the server
 #	will try to switch to user 'zabbix' instead. has no effect if started under a regular user.
@@ -479,7 +479,7 @@ ProxyDataFrequency={{ zabbix_server_proxydatafrequency }}
 AllowRoot={{ zabbix_server_allowroot }}
 {% endif %}
 
-{% if zabbix_version is version_compare('3.0', '>=') %}
+{% if zabbix_version is version('3.0', '>=') %}
 ### Option: User
 #       Drop privileges to a specific, existing user on the system.
 #       Only has effect if run as 'root' and AllowRoot is disabled.
@@ -493,7 +493,7 @@ User={{ zabbix_server_user }}
 #
 Include={{ zabbix_server_include }}
 
-{% if zabbix_version is version_compare('3.0', '>=') %}
+{% if zabbix_version is version('3.0', '>=') %}
 ### Option: SSLCertLocation
 #       Location of SSL client certificates.
 #       This parameter is used only in web monitoring.
@@ -517,7 +517,7 @@ SSLCALocation={{ zabbix_server_sslcalocation }}
 {% endif %}
 
 ####### loadable modules #######
-{% if zabbix_version is version_compare('2.2', '>=') %}
+{% if zabbix_version is version('2.2', '>=') %}
 ### option: loadmodulepath
 #	full path to location of server modules.
 #	default depends on compilation options.
@@ -535,7 +535,7 @@ LoadModulePath={{ zabbix_server_loadmodulepath }}
 LoadModule = {{ loadmodule }}
 {% endif %}
 
-{% if zabbix_version is version_compare('3.0', '>=') %}
+{% if zabbix_version is version('3.0', '>=') %}
 ####### TLS-RELATED PARAMETERS #######
 
 ### Option: TLSCAFile


### PR DESCRIPTION
Jinja filter 'version_compare' deprecated as of Ansible 2.5. Replaced by 'version'.

**Description of PR**
<!--- Describe what the PR holds -->

**Type of change**
<!--- Pick one below and delete the rest: -->

Bugfix Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
#163