### PR TITLE
delegated_dbhost create/import tasks was missing create.sql file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_server_hostname`: The hostname on which the zabbix-server is running. Default set to: {{ inventory_hostname }}
 * `zabbix_server_listenport`: On which port the Zabbix Server is available. Default: 10051
 * `zabbix_server_dbhost`: The hostname on which the database is running.
+* `zabbix_server_real_dbhost`: The hostname of the dbhost that is running behind a loadbalancer/VIP (loadbalancers doesn't accept ssh connections)
 * `zabbix_server_dbname`: The database name which is used by the Zabbix Server.
 * `zabbix_server_dbuser`: The database username which is used by the Zabbix Server.
 * `zabbix_server_dbpassword`: The database user password which is used by the Zabbix Server.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,6 +38,7 @@ zabbix_server_logfilesize: 10
 zabbix_server_debuglevel: 3
 zabbix_server_pidfile: /var/run/zabbix/zabbix_server.pid
 zabbix_server_socketdir: /var/run/zabbix
+zabbix_server_real_dbhost:
 zabbix_server_dbhost: localhost
 zabbix_server_dbname: zabbix-server
 zabbix_server_dbencoding: utf8

--- a/tasks/mysql.yml
+++ b/tasks/mysql.yml
@@ -4,6 +4,11 @@
   set_fact:
     delegated_dbhost: "{{ zabbix_server_dbhost if (zabbix_server_dbhost != 'localhost') else inventory_hostname }}"
 
+- name: "Override delegated_dbhost with real dbhost when dbhost is behind loadbalancer"
+  set_fact:
+    delegated_dbhost: "{{ zabbix_server_real_dbhost }}"
+  when: zabbix_server_real_dbhost | default(false)
+
 - name: "MySQL | Create database"
   mysql_db:
     name: "{{ zabbix_server_dbname }}"
@@ -73,6 +78,26 @@
   tags:
     - zabbix-server
     - database
+
+- name: "Fetch sql create file"
+  fetch:
+    src: "{{ ls_output_create.stdout }}"
+    dest: /tmp/{{ role_name }}/
+    flat: yes
+  when:
+    - delegated_dbhost != inventory_hostname
+    - zabbix_database_sqlload
+    - not done_file.stat.exists
+
+- name: "Copy sql create file"
+  copy:
+    src: /tmp/{{ role_name }}/
+    dest: "{{ ls_output_create.stdout | dirname }}"
+  delegate_to: "{{ delegated_dbhost }}"
+  when:
+    - delegated_dbhost != inventory_hostname
+    - zabbix_database_sqlload
+    - not done_file.stat.exists
 
 - name: "MySQL | Create database and import file >= 3.0"
   mysql_db:


### PR DESCRIPTION
**Description of PR**
We're running zabbix server with a gallera db cluster behind a loadbalancer. For zabbix server the loadbalancer is basically zabbix_server_dbhost.  But the loadbalancer doesn't accept ssh connections so we need to tell ansible to connect with the real dbhost instead of zabbix_server_dbhost. By overriding the delegated_dbhost there's more flexibility in case of cluster setups behind loadbalancers or VIPS. 

With fetch/copy we can supply the dbhost with the correct create.sql file for create/importing of the database. Otherwise it fails because zabbix-server-mysql is not installed on dedicated database hosts. We  copy the create.sql via ansible controller with delegate_to.

**Type of change**
Feature Pull Request

**Fixes an issue**
<!--- If this PR fixes an issue, please mention it. -->
