### PR TITLE
fix issue with datafiles_path on RHEL8

### DIFF
--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -41,6 +41,14 @@
   tags:
     - zabbix-server
 
+- name: "RedHat | Set facts for RHEL8"
+  set_fact:
+    datafiles_path: "/usr/share/doc/zabbix-server-{{ zabbix_server_database }}"
+  when:
+    - ansible_distribution_major_version == "8"
+  tags:
+    - zabbix-server
+
 - name: "Make sure old file is absent"
   file:
     path: /etc/yum.repos.d/zabbix-supported.repo


### PR DESCRIPTION
**Description of PR**
Change datafiles_path for RHEL8

**Type of change**
Bugfix Pull Request

**Fixes an issue**
scripts path in zabbix-server-pgsql is different on RHEL8 than other version