### PR TITLE
Fix check_mode for dpkg_exclude_line.rc on Debian/Ubuntu (Closes: #179)

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -74,6 +74,7 @@
   register: dpkg_exclude_line
   failed_when: false
   changed_when: false
+  check_mode: no
 
 - name: Allow Zabbix dpkg installs to /usr/share/doc/zabbix*
   lineinfile:


### PR DESCRIPTION
**Description of PR**
Disable check_mode for variable filling read-only shell command

**Type of change**
Bugfix Pull Request

**Fixes an issue**
#179
