### PR TITLE
ability to manage zabbix-server service

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The following is an overview of all available configuration default for this rol
 * `zabbix_database_sqlload`:True / False. When you don't want to load the sql files into the database, you can set it to False.
 * `zabbix_server_dbencoding`: The encoding for the MySQL database. Default set to `utf8`
 * `zabbix_server_dbcollation`: The collation for the MySQL database. Default set to `utf8_bin`
+* `zabbix_server_manage_service`: True / False. When you run multiple Zabbix servers in a High Available cluster setup (e.g. pacemaker), you don't want Ansible to manage the zabbix-server service, because Pacemaker is in control of zabbix-server service.
 
 ### Custom Zabbix Scripts
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -118,6 +118,7 @@ zabbix_server_tlskeyfile:
 zabbix_server_startescalators: 1
 zabbix_server_vmwareperffrequency: 60
 zabbix_server_vmwaretimeout: 10
+zabbix_server_manage_service: True
 
 # SELinux specific
 zabbix_selinux: False

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,4 @@
 - name: zabbix-server restarted
   service: name=zabbix-server state=restarted enabled=yes
   tags: zabbix-server
+  when: zabbix_server_manage_service | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,3 +68,4 @@
     enabled: "{{ zabbix_service_enabled }}"
   tags:
     - zabbix-server
+  when: zabbix_server_manage_service | bool


### PR DESCRIPTION
**Description of PR**
When you run Zabbix server in a HA cluster setup you want the resource manager (e.g. Pacemaker) to have control about the zabbix-server service instead of Ansible. Starting zabbix-server on the passive node isn't necessary and can lead to unexpected behaviour. By telling Ansible whether or not it has to manage the service, you can use this role in a HA cluster.

**Type of change**
Feature Pull Request